### PR TITLE
Introduce "composer test" script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 composer.lock
 vendor/
-bin/
 docs/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,4 @@ install:
     - if [ "$DEPENDENCIES" == "lowest" ]; then composer update --prefer-lowest; fi;
 
 script:
-    - bin/behat -f progress
-    - bin/phpunit
-    - bin/phpspec run -f progress
-    - bin/phpcs -p --colors --standard=PSR2 src/ features/bootstrap/
-    - bin/phpcs -p --colors --standard=vendor/jakubzapletal/php_codesniffer-rules/psr2-without-camel-case-method-name.xml spec/ integrations/
+    - composer test

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ $ vendor/bin/phpzone db
 This will compose a proper Docker Compose command `docker-compose -f docker-compose.yml -p myproject up` and
 execute it.
 
+## Development
+
+To run tests, run:
+
+```bash
+$ composer test
+```
+
 ## Documentation
 
 For more details visit [PhpZone Docker documentation].

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,10 @@
         "phpzone/phpzone":  "0.1.*"
     },
 
+    "scripts": {
+        "test": "phpzone tests"
+    },
+
     "extra": {
         "branch-alias": {
             "dev-master": "0.2.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -40,12 +40,12 @@
         }
     },
 
-    "conflict": {
-        "phpzone/phpzone":  "0.1.*"
-    },
-
     "scripts": {
         "test": "phpzone tests"
+    },
+
+    "conflict": {
+        "phpzone/phpzone":  "0.1.*"
     },
 
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,6 @@
         }
     },
 
-    "config": {
-        "bin-dir": "bin/"
-    },
-
     "conflict": {
         "phpzone/phpzone":  "0.1.*"
     },

--- a/phpzone.yml
+++ b/phpzone.yml
@@ -3,8 +3,8 @@ extensions:
         tests:
             description: Run all tests
             script:
-                - bin/behat -f progress
-                - bin/phpunit
-                - bin/phpspec run -f progress
-                - bin/phpcs -p --colors --standard=PSR2 src/ features/bootstrap/
-                - bin/phpcs -p --colors --standard=vendor/jakubzapletal/php_codesniffer-rules/psr2-without-camel-case-method-name.xml spec/ integrations/
+                - behat -f progress
+                - phpunit
+                - phpspec run -f progress
+                - phpcs -p --colors --standard=PSR2 src/ features/bootstrap/
+                - phpcs -p --colors --standard=vendor/jakubzapletal/php_codesniffer-rules/psr2-without-camel-case-method-name.xml spec/ integrations/


### PR DESCRIPTION
[Composer `scripts`](https://getcomposer.org/doc/articles/scripts.md) allows running commands through `composer`, along with the updated `bin` PATHs. We can use this to run the tests through `phpzone` itself.

For some reason, behat is failing for me. [Works on Travis](https://travis-ci.org/phpzone/docker/builds/60882054) though.
